### PR TITLE
set correct name of pod

### DIFF
--- a/react-native-pdf.podspec
+++ b/react-native-pdf.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name           = package['name']
+  s.name           = 'react-native-pdf'
   s.version        = package['version']
   s.summary        = package['summary']
   s.description    = package['description']


### PR DESCRIPTION
This should fix error in pod install:
```
[!] The `react-native-pdf` pod failed to validate due to 1 error:
    - WARN  | attributes: Missing required attribute `license`.
    - WARN  | license: Missing license type.
    - ERROR | [iOS] name: The name of a spec should not contain a slash.
```